### PR TITLE
amk - meta refresh rule causing server issue

### DIFF
--- a/src/app/all-tests/page.tsx
+++ b/src/app/all-tests/page.tsx
@@ -230,7 +230,9 @@ export default function AllTests() {
         <div>Should be tab</div>
       </div>
       <div>
-        <meta http-equiv="refresh" content="10" />
+        <meta http-equiv="refresh" />
+        {/* These two cases cause puppetteer server to disconnect
+        <meta http-equiv="refresh" content="10" /> */}
         <meta http-equiv="refresh" content={(60 * 60 * 20).toString()} />
         <meta http-equiv="content-security-policy" />
         <meta http-equiv="content-type" />

--- a/src/app/all-tests/page.tsx
+++ b/src/app/all-tests/page.tsx
@@ -231,8 +231,7 @@ export default function AllTests() {
       </div>
       <div>
         <meta http-equiv="refresh" />
-        {/* These two cases cause puppetteer server to disconnect
-        <meta http-equiv="refresh" content="10" /> */}
+        <meta http-equiv="refresh" content="60" />
         <meta http-equiv="refresh" content={(60 * 60 * 20).toString()} />
         <meta http-equiv="content-security-policy" />
         <meta http-equiv="content-type" />

--- a/src/app/meta-refresh/page.tsx
+++ b/src/app/meta-refresh/page.tsx
@@ -2,7 +2,7 @@
 export default function Page() {
     return (
         <div>
-            <meta http-equiv="refresh" content="10" />
+            <meta http-equiv="refresh" content="60" />
             <meta http-equiv="refresh" content={(60 * 60 * 20).toString()} />
             <meta http-equiv="content-security-policy" />
             <meta http-equiv="content-type" />


### PR DESCRIPTION
So the tag `<meta http-equiv="refresh" content="60" />` as it suggests refreshes the page after 60 seconds.  The server crash was simply puppeteer not wanting to reconnect.  By bumping up the time to longer than the test needs to run, the server crash is avoided.  
